### PR TITLE
Update air to 0.8.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - { target: linux-64, os: ubuntu-20.04 }
+          - { target: linux-64, os: ubuntu-24.04 }
           - { target: win-64, os: windows-latest }
           - { target: osx-arm64, os: macos-14 }
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,6 @@ jobs:
         include:
           - { target: linux-64, os: ubuntu-20.04 }
           - { target: win-64, os: windows-latest }
-          # force older macos-13 to get x86_64 runners
-          - { target: osx-64, os: macos-13 }
           - { target: osx-arm64, os: macos-14 }
       fail-fast: false
 

--- a/air/recipe.yaml
+++ b/air/recipe.yaml
@@ -22,24 +22,8 @@ requirements:
     - ${{ compiler('rust') }}
 
 tests:
-  - script: |
-      # Test version output
-      air --version | grep "air ${{ version }}"
-
-      # Create test R file
-      cat > test.R << 'EOF'
-      # Simple R code for testing
-      x<-1+2
-      y <- 3 + 4
-      print(x+y)
-      EOF
-
-      # Format the R file
-      air format test.R
-
-      # Check that formatting worked
-      grep "x <- 1 + 2" test.R
-      grep "y <- 3 + 4" test.R
+  - script:
+    - air --help
 
 about:
   homepage: https://github.com/posit-dev/air

--- a/air/recipe.yaml
+++ b/air/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.7.0"
+  version: "0.8.0"
 
 package:
   name: air
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/posit-dev/air/archive/refs/tags/${{ version }}.tar.gz
-  sha256: f33fc7aae6829f8471ca3b9144b0a314137393dc5423e10fa313a43278ffc6eb
+  sha256: fbce4a9698c756dc4d65eb6cb845fcdd8bca952f25b988711037b6ff9b82a99c
 
 build:
   script:


### PR DESCRIPTION
First off, thank you for maintaining this repository of tools!

Here I am updating air to the latest release.

I wasn't sure exactly what the process for contributing here is, as I can't find much in the way of docs, and only found the repo via a [discussion post](https://github.com/prefix-dev/pixi/discussions/2152). Please do let me know if there is anything else that you would need (testing, etc.) to accept the submission. 